### PR TITLE
Fix dotnetRunMessages should be a boolean and not a string

### DIFF
--- a/src/StartProject.Asp/Properties/launchSettings.json
+++ b/src/StartProject.Asp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "StartProject.Asp": {
         "commandName": "Project",
-        "dotnetRunMessages": "true",
+        "dotnetRunMessages": true,
         "launchBrowser": true,
         "applicationUrl": "https://localhost:5000",
         "environmentVariables": {


### PR DESCRIPTION
Running the demo with dotnet run, throws an error, because dotnetRunMessages should be a boolean.
The remaining configuration is not applied either, so that the demo launches as http instead of https.