### PR TITLE
Add configurable BasePath to DemoDocumentLoader

### DIFF
--- a/src/Moryx.Orders.Demo/DemoDocumentLoader.cs
+++ b/src/Moryx.Orders.Demo/DemoDocumentLoader.cs
@@ -4,14 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using MimeTypes;
 using Moryx.Container;
+using Moryx.Modules;
 using Moryx.Orders.Assignment;
 using Moryx.Orders.Documents;
 
 namespace Moryx.Orders.Demo;
+
+[DataContract]
+public class DemoDocumentLoaderConfig : DocumentLoaderConfig
+{
+    [DataMember]
+    public string BasePath { get; set; }
+}
 
 public class LocalDocument : Document
 {
@@ -25,22 +34,27 @@ public class LocalDocument : Document
 }
 
 [Plugin(LifeCycle.Singleton, typeof(IDocumentLoader), Name = nameof(DemoDocumentLoader))]
+[ExpectedConfig(typeof(DemoDocumentLoaderConfig))]
 public class DemoDocumentLoader : IDocumentLoader
 {
-    private DocumentLoaderConfig _config;
+    private DemoDocumentLoaderConfig _config;
 
     public Task InitializeAsync(DocumentLoaderConfig config, CancellationToken cancellationToken = default)
     {
-        _config = config;
+        _config = config as DemoDocumentLoaderConfig;
         return Task.CompletedTask;
     }
 
     public Task<IReadOnlyList<Document>> LoadAsync(Operation operation, CancellationToken cancellationToken)
     {
-        var path = OperatingSystem.IsLinux()
-            ? Path.Combine(Path.GetTempPath(), "MoryxDemo", "Backups", "Orders")
-            : Path.Combine(AppContext.BaseDirectory, "Backups", "Orders");
+        var path = _config?.BasePath;
 
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = OperatingSystem.IsLinux()
+                ? Path.Combine(Path.GetTempPath(), "MoryxDemo", "Backups", "Orders")
+                : Path.Combine(AppContext.BaseDirectory, "Backups", "Orders");
+        }
         if (!Directory.Exists(path))
         {
             Directory.CreateDirectory(path);

--- a/src/Moryx.Orders.Demo/DemoDocumentLoader.cs
+++ b/src/Moryx.Orders.Demo/DemoDocumentLoader.cs
@@ -1,14 +1,15 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using MimeTypes;
 using Moryx.Container;
 using Moryx.Orders.Assignment;
 using Moryx.Orders.Documents;
-using MimeTypes;
-using System.Threading;
 
 namespace Moryx.Orders.Demo;
 
@@ -36,7 +37,10 @@ public class DemoDocumentLoader : IDocumentLoader
 
     public Task<IReadOnlyList<Document>> LoadAsync(Operation operation, CancellationToken cancellationToken)
     {
-        var path = ".\\Backups\\Orders";
+        var path = OperatingSystem.IsLinux()
+            ? Path.Combine(Path.GetTempPath(), "MoryxDemo", "Backups", "Orders")
+            : Path.Combine(AppContext.BaseDirectory, "Backups", "Orders");
+
         if (!Directory.Exists(path))
         {
             Directory.CreateDirectory(path);

--- a/src/Moryx.Orders.Demo/DemoDocumentLoader.cs
+++ b/src/Moryx.Orders.Demo/DemoDocumentLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -19,7 +20,8 @@ namespace Moryx.Orders.Demo;
 public class DemoDocumentLoaderConfig : DocumentLoaderConfig
 {
     [DataMember]
-    public string BasePath { get; set; }
+    [DefaultValue("./Backups/Orders")]
+    public string BasePath { get; set; } = "./Backups/Orders";
 }
 
 public class LocalDocument : Document
@@ -47,14 +49,14 @@ public class DemoDocumentLoader : IDocumentLoader
 
     public Task<IReadOnlyList<Document>> LoadAsync(Operation operation, CancellationToken cancellationToken)
     {
-        var path = _config?.BasePath;
-
-        if (string.IsNullOrWhiteSpace(path))
+        var rawPath = _config?.BasePath;
+        if (string.IsNullOrWhiteSpace(rawPath))
         {
-            path = OperatingSystem.IsLinux()
-                ? Path.Combine(Path.GetTempPath(), "MoryxDemo", "Backups", "Orders")
-                : Path.Combine(AppContext.BaseDirectory, "Backups", "Orders");
+            rawPath = "./Backups/Orders";
         }
+
+        var path = Path.GetFullPath(rawPath);
+
         if (!Directory.Exists(path))
         {
             Directory.CreateDirectory(path);


### PR DESCRIPTION
Added a configurable 'BasePath' property with a default value to the DemoDocumentLoader, allowing the path to be overwritten while fixing the path resolution to prevent permission errors.